### PR TITLE
Bump aws version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,15 @@ Currently the module configures two output streams: one for S3 delivery, and ano
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| terraform | >= 0.13 |
+| aws | >= 3.15 |
 | random | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.68 |
+| aws | >= 3.15 |
 | random | >= 3.0.0 |
 
 ## Inputs

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68"
+    aws    = ">= 3.15"
     random = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
`http_endpoint_configuration` configuration block was only added in
terraform-provider-aws 3.15.0
(https://github.com/hashicorp/terraform-provider-aws/pull/15356)