### PR TITLE
cloudwatch_logs_subscription: allow overriding role

### DIFF
--- a/cloudwatch_logs_subscription/README.md
+++ b/cloudwatch_logs_subscription/README.md
@@ -60,6 +60,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_filter_name"></a> [filter\_name](#input\_filter\_name) | Filter name | `string` | `"observe-filter"` | no |
 | <a name="input_filter_pattern"></a> [filter\_pattern](#input\_filter\_pattern) | The filter pattern to use. For more information, see [Filter and Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) | `string` | `""` | no |
+| <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-kinesis-firehose-"` | no |
+| <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | ARN of IAM role to use for Cloudwatch Logs subscription | `string` | `""` | no |
 | <a name="input_kinesis_firehose"></a> [kinesis\_firehose](#input\_kinesis\_firehose) | Observe Kinesis Firehose module | <pre>object({<br>    firehose_delivery_stream = object({ arn = string })<br>    firehose_iam_policy      = object({ arn = string })<br>  })</pre> | n/a | yes |
 | <a name="input_log_group_names"></a> [log\_group\_names](#input\_log\_group\_names) | Cloudwatch Log Group names to subscribe to Observe Lambda | `list(string)` | n/a | yes |
 

--- a/cloudwatch_logs_subscription/main.tf
+++ b/cloudwatch_logs_subscription/main.tf
@@ -1,4 +1,11 @@
+locals {
+  iam_role_arn  = var.iam_role_arn != "" ? var.iam_role_arn : aws_iam_role.this[0].arn
+  iam_role_name = regex(".*role/(?P<role_name>.*)$", local.iam_role_arn)["role_name"]
+}
+
 resource "aws_iam_role" "this" {
+  count              = var.iam_role_arn == "" ? 1 : 0
+  name_prefix        = var.iam_name_prefix
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -17,7 +24,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
-  role       = aws_iam_role.this.name
+  role       = local.iam_role_name
   policy_arn = var.kinesis_firehose.firehose_iam_policy.arn
 }
 
@@ -26,6 +33,6 @@ resource "aws_cloudwatch_log_subscription_filter" "subscription_filter" {
   name            = var.filter_name
   log_group_name  = var.log_group_names[count.index]
   filter_pattern  = var.filter_pattern
-  role_arn        = aws_iam_role.this.arn
+  role_arn        = local.iam_role_arn
   destination_arn = var.kinesis_firehose.firehose_delivery_stream.arn
 }

--- a/cloudwatch_logs_subscription/variables.tf
+++ b/cloudwatch_logs_subscription/variables.tf
@@ -22,3 +22,15 @@ variable "filter_name" {
   type        = string
   default     = "observe-filter"
 }
+
+variable "iam_name_prefix" {
+  description = "Prefix used for all created IAM roles and policies"
+  type        = string
+  default     = "observe-kinesis-firehose-"
+}
+
+variable "iam_role_arn" {
+  description = "ARN of IAM role to use for Cloudwatch Logs subscription"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This brings module in line with others, and allows us to consistently set IAM name prefixes.