### PR TITLE
fix: adjust EKS variables, remove provider

### DIFF
--- a/eks/README.md
+++ b/eks/README.md
@@ -78,8 +78,6 @@ module "observe_kinesis_firehose" {
 | [aws_iam_role_policy_attachment.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [kubernetes_config_map_v1.aws_logging](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_namespace_v1.aws_observability](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
-| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
-| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [kubernetes_namespace_v1.default](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/namespace_v1) | data source |
 
@@ -87,7 +85,7 @@ module "observe_kinesis_firehose" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | EKS cluster name | `string` | n/a | yes |
+| <a name="input_eks_cluster_arn"></a> [eks\_cluster\_arn](#input\_eks\_cluster\_arn) | EKS cluster ARN | `string` | n/a | yes |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
 | <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe Token | `string` | n/a | yes |

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,23 +1,11 @@
 locals {
   role_regex               = "arn:aws:iam::\\d{12}:role/(?P<name>.+)"
-  pod_execution_role_names = toset([for i in var.pod_execution_role_arns : regex(local.role_regex, i)["name"]])
+  name_regex               = "arn:aws:eks:[^:]+:\\d{12}:cluster/(?P<name>.+)"
+  pod_execution_role_names = [for i in var.pod_execution_role_arns : regex(local.role_regex, i)["name"]]
+  eks_cluster_name         = regex(local.name_regex, var.eks_cluster_arn)["name"]
 }
 
 data "aws_region" "current" {}
-
-data "aws_eks_cluster" "this" {
-  name = var.eks_cluster_name
-}
-
-data "aws_eks_cluster_auth" "this" {
-  name = data.aws_eks_cluster.this.name
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.this.token
-}
 
 data "kubernetes_namespace_v1" "default" {
   metadata {
@@ -28,7 +16,7 @@ data "kubernetes_namespace_v1" "default" {
 resource "kubernetes_namespace_v1" "aws_observability" {
   metadata {
     annotations = {
-      "observeinc.com/cluster-name" = data.aws_eks_cluster.this.arn
+      "observeinc.com/cluster-name" = var.eks_cluster_arn
     }
 
     labels = {
@@ -42,7 +30,7 @@ resource "kubernetes_namespace_v1" "aws_observability" {
 module "observe_kinesis" {
   source = "./.."
 
-  name             = format("observe-eks-%s", data.aws_eks_cluster.this.name)
+  name             = format("observe-eks-%s", local.eks_cluster_name)
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
   observe_url      = format("https://kinesis.collect.%s", var.observe_domain)
@@ -52,8 +40,8 @@ module "observe_kinesis" {
 }
 
 resource "aws_iam_role_policy_attachment" "firehose" {
-  for_each   = local.pod_execution_role_names
-  role       = each.value
+  count      = length(local.pod_execution_role_names)
+  role       = local.pod_execution_role_names[count.index]
   policy_arn = module.observe_kinesis.firehose_iam_policy.arn
 }
 

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -14,9 +14,13 @@ variable "observe_domain" {
   default     = "observeinc.com"
 }
 
-variable "eks_cluster_name" {
-  description = "EKS cluster name"
+variable "eks_cluster_arn" {
+  description = "EKS cluster ARN"
   type        = string
+  validation {
+    condition     = try(regex("arn:aws:eks:[^:]+:\\d{12}:cluster/.+", var.eks_cluster_arn), null) != null
+    error_message = "ARN identifier is malformed."
+  }
 }
 
 variable "pod_execution_role_arns" {

--- a/examples/eks/README.md
+++ b/examples/eks/README.md
@@ -1,0 +1,65 @@
+# EKS to Observe 
+
+The configuration in this directory documents how to create an EKS Cluster and
+wire Fargate nodes to send logs to Observe via a Kinesis Firehose delivery
+stream.
+
+## Usage
+
+To run this example, execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this will create AWS resources - once you are done, run `terraform destroy`.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.20.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.20.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 18.3.1 |
+| <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | ../..//eks | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.2.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_subnet.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster Name | `string` | `"observe-eks-demo"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS Cluster Version | `string` | `"1.21"` | no |
+| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |
+| <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/eks/eks.tf
+++ b/examples/eks/eks.tf
@@ -1,0 +1,38 @@
+module "eks" {
+  source          = "terraform-aws-modules/eks/aws"
+  version         = "18.3.1"
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+  subnet_ids      = module.vpc.private_subnets
+
+  vpc_id = module.vpc.vpc_id
+
+  self_managed_node_group_defaults = {
+    root_volume_type = "gp2"
+  }
+
+  fargate_profiles = {
+    default = {
+      name = "default"
+      selectors = [
+        {
+          namespace = "kube-system"
+        },
+        {
+          namespace = "default"
+        },
+        {
+          namespace = "observe"
+        },
+      ]
+
+      tags = {}
+
+      timeouts = {
+        create = "20m"
+        delete = "20m"
+      }
+    }
+  }
+}
+

--- a/examples/eks/main.tf
+++ b/examples/eks/main.tf
@@ -1,0 +1,25 @@
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+}
+
+module "observe_kinesis_firehose" {
+  source = "../..//eks"
+
+  observe_customer = var.observe_customer
+  observe_token    = var.observe_token
+  observe_domain   = var.observe_domain
+
+  eks_cluster_arn         = module.eks.cluster_arn
+  pod_execution_role_arns = [for group in module.eks.fargate_profiles : group.fargate_profile_pod_execution_role_arn]
+  depends_on              = [module.eks]
+}

--- a/examples/eks/variables.tf
+++ b/examples/eks/variables.tf
@@ -1,0 +1,28 @@
+variable "cluster_name" {
+  description = "EKS Cluster Name"
+  type        = string
+  default     = "observe-eks-demo"
+}
+
+variable "cluster_version" {
+  description = "EKS Cluster Version"
+  type        = string
+  default     = "1.21"
+}
+
+
+variable "observe_customer" {
+  description = "Observe Customer ID"
+  type        = string
+}
+
+variable "observe_token" {
+  description = "Observe token"
+  type        = string
+}
+
+variable "observe_domain" {
+  description = "Observe Domain"
+  type        = string
+  default     = "observeinc.com"
+}

--- a/examples/eks/versions.tf
+++ b/examples/eks/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "3.1.0"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.1"
+    }
+  }
+
+  required_version = ">= 0.14"
+}

--- a/examples/eks/vpc.tf
+++ b/examples/eks/vpc.tf
@@ -1,0 +1,38 @@
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.2.0"
+
+  name                 = var.cluster_name
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+}
+
+resource "aws_subnet" "main" {
+  vpc_id     = module.vpc.vpc_id
+  cidr_block = "10.0.0.0/24"
+
+  tags = {
+    Name = "Main"
+  }
+}


### PR DESCRIPTION
Fixes based on experimentation with `terraform-aws-modules/eks/aws`:

- we cannot declare a provider within a module, if we then wish to compose that
  module with others. Providers are global, so it causes very odd interactions.
  Users must configure the kubernetes provider for their EKS cluster themselves :(
- avoid using data sources, you can get stuck during destroy due if users did
  not explicitly depend on the right resources.

This commit also adds a `examples/eks` module with a full set up for an EKS
cluster with Fargate logging towards Observe.