### PR TITLE
fix: pin upperbound AWS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ This repository contains examples of how to solve for concrete usecases:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15, < 4.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15, < 4.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/cloudwatch_logs_subscription/README.md
+++ b/cloudwatch_logs_subscription/README.md
@@ -34,13 +34,13 @@ module "observe_kinesis_firehose_cloudwatch_logs_subscription" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68, < 4.0 |
 
 ## Modules
 

--- a/cloudwatch_logs_subscription/versions.tf
+++ b/cloudwatch_logs_subscription/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = ">= 2.68, < 4.0"
   }
 }

--- a/cloudwatch_metrics/README.md
+++ b/cloudwatch_metrics/README.md
@@ -44,13 +44,13 @@ module "cloudwatch_metrics" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.42.0, < 4.0 |
 
 ## Modules
 

--- a/cloudwatch_metrics/versions.tf
+++ b/cloudwatch_metrics/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.42.0"
+    aws = ">= 3.42.0, < 4.0"
   }
 }

--- a/eks/README.md
+++ b/eks/README.md
@@ -54,7 +54,7 @@ module "observe_kinesis_firehose" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15, < 4.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -62,7 +62,7 @@ module "observe_kinesis_firehose" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15, < 4.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0 |
 
 ## Modules

--- a/eks/versions.tf
+++ b/eks/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws        = ">= 3.15"
+    aws        = ">= 3.15, < 4.0"
     kubernetes = ">= 2.0"
     random     = ">= 3.0.0"
   }

--- a/eventbridge/README.md
+++ b/eventbridge/README.md
@@ -43,14 +43,14 @@ module "observe_firehose_eventbridge" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15, < 4.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15, < 4.0 |
 
 ## Modules
 

--- a/eventbridge/versions.tf
+++ b/eventbridge/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 3.15"
+    aws    = ">= 3.15, < 4.0"
     random = ">= 3.0.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 3.15"
+    aws    = ">= 3.15, < 4.0"
     random = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
Due to changes to `aws_s3_bucket`, we do not currently support AWS provider
4.0+