### PR TITLE
feat: introduce observe_domain var

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,9 @@ No modules.
 | <a name="input_kinesis_stream"></a> [kinesis\_stream](#input\_kinesis\_stream) | Kinesis Data Stream ARN to configure as source | `object({ arn = string })` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of Kinesis Firehose resource | `string` | n/a | yes |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe Token | `string` | n/a | yes |
-| <a name="input_observe_url"></a> [observe\_url](#input\_observe\_url) | Observe URL | `string` | `"https://kinesis.collect.observeinc.com"` | no |
+| <a name="input_observe_url"></a> [observe\_url](#input\_observe\_url) | Observe URL. Deprecated. | `string` | `""` | no |
 | <a name="input_s3_delivery_bucket"></a> [s3\_delivery\_bucket](#input\_s3\_delivery\_bucket) | S3 bucket to be used as backup for message delivery | <pre>object({<br>    arn = string<br>  })</pre> | `null` | no |
 | <a name="input_s3_delivery_buffer_interval"></a> [s3\_delivery\_buffer\_interval](#input\_s3\_delivery\_buffer\_interval) | Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. | `number` | `300` | no |
 | <a name="input_s3_delivery_buffer_size"></a> [s3\_delivery\_buffer\_size](#input\_s3\_delivery\_buffer\_size) | Buffer incoming data to the specified size, in MiBs, before delivering it to the destination. | `number` | `5` | no |

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -33,7 +33,7 @@ module "observe_kinesis" {
   name             = format("observe-eks-%s", local.eks_cluster_name)
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
-  observe_url      = format("https://kinesis.collect.%s", var.observe_domain)
+  observe_domain   = var.observe_domain
   common_attributes = {
     clusterUid = data.kubernetes_namespace_v1.default.metadata[0].uid
   }

--- a/examples/cross-account/README.md
+++ b/examples/cross-account/README.md
@@ -91,8 +91,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | <a name="input_external_ids"></a> [external\_ids](#input\_external\_ids) | External ID array | `list(string)` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for firehose and matching IAM role | `string` | n/a | yes |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
-| <a name="input_observe_url"></a> [observe\_url](#input\_observe\_url) | Observe URL | `string` | `"https://kinesis.collect.observeinc.com"` | no |
 | <a name="input_user_arn"></a> [user\_arn](#input\_user\_arn) | ARN for external user granted access to assume role | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/cross-account/main.tf
+++ b/examples/cross-account/main.tf
@@ -11,7 +11,7 @@ module "observe_kinesis_firehose" {
   source           = "../.."
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
-  observe_url      = var.observe_url
+  observe_domain   = var.observe_domain
 
   name                 = var.name
   cloudwatch_log_group = aws_cloudwatch_log_group.group

--- a/examples/cross-account/variables.tf
+++ b/examples/cross-account/variables.tf
@@ -8,10 +8,10 @@ variable "observe_token" {
   type        = string
 }
 
-variable "observe_url" {
-  description = "Observe URL"
+variable "observe_domain" {
+  description = "Observe domain"
   type        = string
-  default     = "https://kinesis.collect.observeinc.com"
+  default     = "observeinc.com"
 }
 
 variable "name" {

--- a/examples/eventbridge/README.md
+++ b/examples/eventbridge/README.md
@@ -54,8 +54,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
-| <a name="input_observe_url"></a> [observe\_url](#input\_observe\_url) | Observe URL | `string` | `"https://kinesis.collect.observeinc.com"` | no |
 
 ## Outputs
 

--- a/examples/eventbridge/main.tf
+++ b/examples/eventbridge/main.tf
@@ -13,7 +13,7 @@ module "observe_kinesis_firehose" {
   source           = "../.."
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
-  observe_url      = var.observe_url
+  observe_domain   = var.observe_domain
 
   name                 = random_pet.run.id
   cloudwatch_log_group = aws_cloudwatch_log_group.group

--- a/examples/eventbridge/variables.tf
+++ b/examples/eventbridge/variables.tf
@@ -8,8 +8,8 @@ variable "observe_token" {
   type        = string
 }
 
-variable "observe_url" {
-  description = "Observe URL"
+variable "observe_domain" {
+  description = "Observe domain"
   type        = string
-  default     = "https://kinesis.collect.observeinc.com"
+  default     = "observeinc.com"
 }

--- a/examples/kinesis/README.md
+++ b/examples/kinesis/README.md
@@ -57,8 +57,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
-| <a name="input_observe_url"></a> [observe\_url](#input\_observe\_url) | Observe URL | `string` | `"https://kinesis.collect.observeinc.com"` | no |
 
 ## Outputs
 

--- a/examples/kinesis/main.tf
+++ b/examples/kinesis/main.tf
@@ -8,7 +8,7 @@ module "observe_kinesis" {
   source           = "../.."
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
-  observe_url      = var.observe_url
+  observe_domain   = var.observe_domain
 
   name           = random_pet.run.id
   kinesis_stream = aws_kinesis_stream.this

--- a/examples/kinesis/variables.tf
+++ b/examples/kinesis/variables.tf
@@ -8,8 +8,8 @@ variable "observe_token" {
   type        = string
 }
 
-variable "observe_url" {
-  description = "Observe URL"
+variable "observe_domain" {
+  description = "Observe domain"
   type        = string
-  default     = "https://kinesis.collect.observeinc.com"
+  default     = "observeinc.com"
 }

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ locals {
   access_key                   = format("%s %s", var.observe_customer, var.observe_token)
   create_s3_bucket             = var.s3_delivery_bucket == null
   s3_bucket_arn                = local.create_s3_bucket ? aws_s3_bucket.bucket[0].arn : var.s3_delivery_bucket.arn
+  observe_url                  = var.observe_url != "" ? var.observe_url : format("https://collect.%s/v1/kinesis", var.observe_domain)
 }
 
 resource "random_string" "bucket_suffix" {
@@ -53,7 +54,7 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
   }
 
   http_endpoint_configuration {
-    url            = var.observe_url
+    url            = local.observe_url
     name           = var.http_endpoint_name
     access_key     = local.access_key
     role_arn       = aws_iam_role.firehose.arn

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "observe_token" {
   type        = string
 }
 
+variable "observe_domain" {
+  description = "Observe domain"
+  type        = string
+  default     = "observeinc.com"
+}
+
 variable "s3_delivery_bucket" {
   description = "S3 bucket to be used as backup for message delivery"
   type = object({
@@ -23,9 +29,9 @@ variable "s3_delivery_bucket" {
 
 # Optional input variables
 variable "observe_url" {
-  description = "Observe URL"
+  description = "Observe URL. Deprecated."
   type        = string
-  default     = "https://kinesis.collect.observeinc.com"
+  default     = ""
 }
 
 variable "http_endpoint_name" {


### PR DESCRIPTION
This normalizes this module with the variables used across our remaining
terraform modules. `observe_url` will be deprecated.

Additionally, update the default endpoint to point at
`collect.observeinc.com/v1/kinesis` rather than
`kinesis.collect.observeinc.com`.