### PR TITLE
fix: migrate to aws_s3_bucket_acl

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ This repository contains examples of how to solve for concrete usecases:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15, < 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
@@ -154,6 +154,7 @@ No modules.
 | [aws_iam_role_policy_attachment.kinesis_firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kinesis_firehose_delivery_stream.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [random_string.bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -20,8 +20,14 @@ resource "aws_s3_bucket" "bucket" {
   count = local.create_s3_bucket ? 1 : 0
 
   bucket        = format("%s-%s", var.name, random_string.bucket_suffix[0].result)
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "bucket" {
+  count = local.create_s3_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket[0].id
+  acl    = "private"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "this" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 3.15, < 4.0"
+    aws    = ">= 3.75"
     random = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
This allows us to support newer AWS provider (from 4.0 onwards). Caveat is that we now no longer support AWS providers prior to 3.75.