### PR TITLE
fix: improve tags coverage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
 
 resource "aws_iam_role" "firehose" {
   name_prefix        = var.iam_name_prefix
+  tags               = var.tags
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -111,6 +112,7 @@ EOF
 
 resource "aws_iam_policy" "firehose_s3" {
   name_prefix = var.iam_name_prefix
+  tags        = var.tags
   policy      = <<-EOF
 {
   "Version": "2012-10-17",
@@ -143,6 +145,7 @@ resource "aws_iam_role_policy_attachment" "firehose_s3" {
 
 resource "aws_iam_policy" "put_record" {
   name_prefix = var.iam_name_prefix
+  tags        = var.tags
   policy      = <<-EOF
 {
     "Version": "2012-10-17",
@@ -177,6 +180,7 @@ resource "aws_cloudwatch_log_stream" "s3_delivery" {
 resource "aws_iam_policy" "firehose_cloudwatch" {
   name_prefix = var.iam_name_prefix
   count       = local.enable_cloudwatch ? 1 : 0
+  tags        = var.tags
 
   policy = <<EOF
 {
@@ -206,8 +210,9 @@ resource "aws_iam_role_policy_attachment" "firehose_cloudwatch" {
 }
 
 resource "aws_iam_policy" "kinesis_firehose" {
-  name_prefix = var.iam_name_prefix
   count       = local.enable_kinesis_source ? 1 : 0
+  name_prefix = var.iam_name_prefix
+  tags        = var.tags
 
   policy = <<EOF
 {

--- a/modules/cloudwatch_metrics/README.md
+++ b/modules/cloudwatch_metrics/README.md
@@ -74,6 +74,7 @@ No modules.
 | <a name="input_include_filters"></a> [include\_filters](#input\_include\_filters) | Namespaces to include. Mutually exclusive with exclude\_filters. | `list(string)` | `[]` | no |
 | <a name="input_kinesis_firehose"></a> [kinesis\_firehose](#input\_kinesis\_firehose) | Observe Kinesis Firehose module | <pre>object({<br>    firehose_delivery_stream = object({ arn = string })<br>    firehose_iam_policy      = object({ arn = string })<br>  })</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of Cloudwatch Metrics Stream and CloudFormation stack | `string` | `"observe-cwmetricsstream"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/cloudwatch_metrics/main.tf
+++ b/modules/cloudwatch_metrics/main.tf
@@ -6,6 +6,7 @@ locals {
 resource "aws_iam_role" "this" {
   count              = var.iam_role_arn == "" ? 1 : 0
   name_prefix        = var.iam_name_prefix
+  tags               = var.tags
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -33,6 +34,7 @@ resource "aws_cloudwatch_metric_stream" "main" {
   role_arn      = local.iam_role_arn
   firehose_arn  = var.kinesis_firehose.firehose_delivery_stream.arn
   output_format = "json"
+  tags          = var.tags
 
   dynamic "include_filter" {
     for_each = var.include_filters

--- a/modules/cloudwatch_metrics/variables.tf
+++ b/modules/cloudwatch_metrics/variables.tf
@@ -35,3 +35,9 @@ variable "exclude_filters" {
   type        = list(string)
   default     = []
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -72,6 +72,7 @@ No modules.
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | ARN of IAM role to use for EventBridge target | `string` | `""` | no |
 | <a name="input_kinesis_firehose"></a> [kinesis\_firehose](#input\_kinesis\_firehose) | Observe Kinesis Firehose module | <pre>object({<br>    firehose_delivery_stream = object({ arn = string })<br>    firehose_iam_policy      = object({ arn = string })<br>  })</pre> | n/a | yes |
 | <a name="input_rules"></a> [rules](#input\_rules) | List of EventBridge rules to subscribe to Firehose | `list(object({ name = string }))` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -6,6 +6,7 @@ locals {
 resource "aws_iam_role" "this" {
   count              = var.iam_role_arn == "" ? 1 : 0
   name_prefix        = var.iam_name_prefix
+  tags               = var.tags
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -23,3 +23,9 @@ variable "rules" {
   type        = list(object({ name = string }))
   default     = []
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This commit ensures a `tags` variable can be passed to all submodules, as well as wiring it through to resources where it was absent.