### PR TITLE
fix(eventbridge)!: make rules order independent

### DIFF
--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -71,7 +71,7 @@ No modules.
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-kinesis-firehose-"` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | ARN of IAM role to use for EventBridge target | `string` | `""` | no |
 | <a name="input_kinesis_firehose"></a> [kinesis\_firehose](#input\_kinesis\_firehose) | Observe Kinesis Firehose module | <pre>object({<br>    firehose_delivery_stream = object({ arn = string })<br>    firehose_iam_policy      = object({ arn = string })<br>  })</pre> | n/a | yes |
-| <a name="input_rules"></a> [rules](#input\_rules) | List of EventBridge rules to subscribe to Firehose | `list(object({ name = string }))` | `[]` | no |
+| <a name="input_rules"></a> [rules](#input\_rules) | Set of EventBridge rules to subscribe to Firehose | `set(object({ name = string }))` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -30,8 +30,8 @@ resource "aws_iam_role_policy_attachment" "firehose" {
 }
 
 resource "aws_cloudwatch_event_target" "firehose" {
-  count    = length(var.rules)
+  for_each = { for r in var.rules : r.name => r }
   arn      = var.kinesis_firehose.firehose_delivery_stream.arn
-  rule     = var.rules[count.index].name
   role_arn = local.iam_role_arn
+  rule     = each.value.name
 }

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -19,8 +19,8 @@ variable "iam_role_arn" {
 }
 
 variable "rules" {
-  description = "List of EventBridge rules to subscribe to Firehose"
-  type        = list(object({ name = string }))
+  description = "Set of EventBridge rules to subscribe to Firehose"
+  type        = set(object({ name = string }))
   default     = []
 }
 


### PR DESCRIPTION
This commit replaces `count` with `for_each`, making the behavior of the module independent from the order in which rules are provided. Targets become instead tied to the rule name, which is less surprising to users inspecting a plan.