### PR TITLE
feat(eventbridge)!: switch `rules` variable to type `map`

### DIFF
--- a/examples/eventbridge/eventbridge.tf
+++ b/examples/eventbridge/eventbridge.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_event_rule" "scheduled" {
 module "observe_eventbridge_kinesis" {
   source           = "../../modules/eventbridge"
   kinesis_firehose = module.observe_kinesis_firehose
-  rules = [
-    aws_cloudwatch_event_rule.scheduled,
-  ]
+  rules = {
+    scheduled = aws_cloudwatch_event_rule.scheduled
+  }
 }

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -2,10 +2,6 @@
 
 Terraform module which sets up a Kinesis Firehose delivery stream as a target for Eventbridge Events
 
-## Terraform versions
-
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
@@ -31,9 +27,9 @@ module "observe_firehose_eventbridge" {
   source           = "github.com/observeinc/terraform-aws-kinesis-firehose//eventbridge"
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = var.name
-  rules = [
-    aws_cloudwatch_event_rule.wildcard,
-  ]
+  rules = {
+    wildcard = aws_cloudwatch_event_rule.wildcard
+  }
 }
 ```
 
@@ -71,7 +67,7 @@ No modules.
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-kinesis-firehose-"` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | ARN of IAM role to use for EventBridge target | `string` | `""` | no |
 | <a name="input_kinesis_firehose"></a> [kinesis\_firehose](#input\_kinesis\_firehose) | Observe Kinesis Firehose module | <pre>object({<br>    firehose_delivery_stream = object({ arn = string })<br>    firehose_iam_policy      = object({ arn = string })<br>  })</pre> | n/a | yes |
-| <a name="input_rules"></a> [rules](#input\_rules) | Set of EventBridge rules to subscribe to Firehose | `set(object({ name = string }))` | `[]` | no |
+| <a name="input_rules"></a> [rules](#input\_rules) | Map of EventBridge rules to subscribe to Firehose. Keys are<br>only used to provide stable resource addresses. | `map(object({ name = string }))` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role_policy_attachment" "firehose" {
 }
 
 resource "aws_cloudwatch_event_target" "firehose" {
-  for_each = { for r in var.rules : r.name => r }
+  for_each = var.rules
   arn      = var.kinesis_firehose.firehose_delivery_stream.arn
   role_arn = local.iam_role_arn
   rule     = each.value.name

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -21,10 +21,13 @@ variable "iam_role_arn" {
 }
 
 variable "rules" {
-  description = "Set of EventBridge rules to subscribe to Firehose"
-  type        = set(object({ name = string }))
+  description = <<-EOF
+    Map of EventBridge rules to subscribe to Firehose. Keys are
+    only used to provide stable resource addresses.
+  EOF
+  type        = map(object({ name = string }))
   nullable    = false
-  default     = []
+  default     = {}
 }
 
 variable "tags" {


### PR DESCRIPTION
As part of the migration to `for_each`, we need to provide users with a means of providing identifiers that are known at apply time. Allow users to provide stable identifiers through the keys in a map.

BREAKING CHANGE: `rules` must be converted from a list to a map. Keys in this map are only used for addressing purposes within terraform.