### PR TITLE
docs: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,11 @@ Additionally, this repository provides submodules to interact with the Firehose 
 * [Collect EventBridge](https://github.com/observeinc/terraform-aws-kinesis-firehose/tree/main/eventbridge)
 * [Collect EKS Fargate logs](https://github.com/observeinc/terraform-aws-kinesis-firehose/tree/main/eks)
 
-## Terraform versions
-
-Terraform 0.13 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
 module "observe_kinesis_firehose" {
-  source = "github.com/observeinc/terraform-aws-kinesis-firehose"
+  source = "observeinc/kinesis-firehose/aws"
 
   name                = "observe-kinesis-firehose"
   observe_customer    = "<id>"

--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -3,8 +3,6 @@
 Given a list of Cloudwatch Log Group names and an Observe Kinesis Firehose module, this 
 module subscribes each Log Group to the Kinesis Firehose.
 
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
@@ -13,14 +11,14 @@ resource "aws_cloudwatch_log_group" "group" {
 }
 
 module "observe_kinesis_firehose" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose"
+  source           = "observeinc/kinesis-firehose/aws"
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
   name             = random_pet.run.id
 }
 
 module "observe_kinesis_firehose_cloudwatch_logs_subscription" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose//cloudwatch_logs_subscription"
+  source           = "observeinc/kinesis-firehose/aws//cloudwatch_logs_subscription"
   kinesis_firehose = module.observe_kinesis_firehose
   log_group_names  = [
     aws_cloudwatch_log_group.group.name

--- a/modules/cloudwatch_metrics/README.md
+++ b/modules/cloudwatch_metrics/README.md
@@ -8,22 +8,18 @@ supported in the terraform AWS provider. This module uses a CloudFormation
 template to configure a Cloudwatch Metric Stream towards an existing Kinesis
 Firehose.
 
-## Terraform versions
-
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
 module "kinesis_firehose" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose"
+  source           = "observeinc/kinesis-firehose/aws"
   name             = var.name
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
 }
 
 module "cloudwatch_metrics" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose//cloudwatch_metrics"
+  source           = "observeinc/kinesis-firehose/aws//cloudwatch_metrics"
   kinesis_firehose = module.kinesis_firehose
 }
 ```
@@ -32,7 +28,7 @@ You can also provide `include_filters` or `exclude_filters`, e.g:
 
 ```
 module "cloudwatch_metrics" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose//cloudwatch_metrics"
+  source           = "observeinc/kinesis-firehose/aws//cloudwatch_metrics"
   kinesis_firehose = module.kinesis_firehose
   exclude_filters  = ["AWS/Firehose"]
 }

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -2,10 +2,6 @@
 
 Terraform module which sets up a Kinesis Firehose delivery stream as a target for Eventbridge Events
 
-## Terraform versions
-
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
@@ -20,7 +16,7 @@ resource "aws_cloudwatch_event_rule" "wildcard" {
 }
 
 module "observe_kinesis_firehose" {
-  source = "github.com/observeinc/terraform-aws-kinesis-firehose?ref=main"
+  source = "observeinc/kinesis-firehose/aws"
 
   name             = "observe-kinesis-firehose"
   observe_customer = var.observe_customer
@@ -28,7 +24,7 @@ module "observe_kinesis_firehose" {
 }
 
 module "observe_firehose_eventbridge" {
-  source           = "github.com/observeinc/terraform-aws-kinesis-firehose//eventbridge"
+  source           = "observeinc/kinesis-firehose/aws//eventbridge"
   kinesis_firehose = module.observe_kinesis_firehose
   iam_name_prefix  = var.name
   rules = [


### PR DESCRIPTION
The terraform provider requirements are already compiled by terraform-docs.

Module sources should point towards module registry.

Suggestions on how to contribute should be instead provided via CONTRIBUTING file.
