### PR TITLE
feat(cloudwatch_metrics)!: introduce `nullable`

### DIFF
--- a/modules/cloudwatch_metrics/README.md
+++ b/modules/cloudwatch_metrics/README.md
@@ -43,7 +43,7 @@ module "cloudwatch_metrics" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0 |
 
 ## Providers
@@ -68,10 +68,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_exclude_filters"></a> [exclude\_filters](#input\_exclude\_filters) | Namespaces to exclude. Mutually exclusive with include\_filters. | `list(string)` | `[]` | no |
+| <a name="input_exclude_filters"></a> [exclude\_filters](#input\_exclude\_filters) | Namespaces to exclude. Mutually exclusive with include\_filters. | `set(string)` | `[]` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-cwmetricsstream-"` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | ARN of IAM role to use for Cloudwatch Metrics Stream | `string` | `""` | no |
-| <a name="input_include_filters"></a> [include\_filters](#input\_include\_filters) | Namespaces to include. Mutually exclusive with exclude\_filters. | `list(string)` | `[]` | no |
+| <a name="input_include_filters"></a> [include\_filters](#input\_include\_filters) | Namespaces to include. Mutually exclusive with exclude\_filters. | `set(string)` | `[]` | no |
 | <a name="input_kinesis_firehose"></a> [kinesis\_firehose](#input\_kinesis\_firehose) | Observe Kinesis Firehose module | <pre>object({<br>    firehose_delivery_stream = object({ arn = string })<br>    firehose_iam_policy      = object({ arn = string })<br>  })</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of Cloudwatch Metrics Stream and CloudFormation stack | `string` | `"observe-cwmetricsstream"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/cloudwatch_metrics/variables.tf
+++ b/modules/cloudwatch_metrics/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "Name of Cloudwatch Metrics Stream and CloudFormation stack"
   type        = string
+  nullable    = false
   default     = "observe-cwmetricsstream"
 }
 
@@ -15,29 +16,34 @@ variable "kinesis_firehose" {
 variable "iam_name_prefix" {
   description = "Prefix used for all created IAM roles and policies"
   type        = string
+  nullable    = false
   default     = "observe-cwmetricsstream-"
 }
 
 variable "iam_role_arn" {
   description = "ARN of IAM role to use for Cloudwatch Metrics Stream"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "include_filters" {
   description = "Namespaces to include. Mutually exclusive with exclude_filters."
-  type        = list(string)
+  type        = set(string)
+  nullable    = false
   default     = []
 }
 
 variable "exclude_filters" {
   description = "Namespaces to exclude. Mutually exclusive with include_filters."
-  type        = list(string)
+  type        = set(string)
+  nullable    = false
   default     = []
 }
 
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)
+  nullable    = false
   default     = {}
 }

--- a/modules/cloudwatch_metrics/versions.tf
+++ b/modules/cloudwatch_metrics/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = ">= 3.42.0"


### PR DESCRIPTION
Missed this in a prior commit.

Where applicable, we convert `list(string)` to `set(string)`. This is functionally equivalent, but provides more accurate documentation as to variable behavior.