### PR TITLE
fix: pin upperbound version of AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ This repository contains examples of how to solve for concrete usecases:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75,<5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75,<5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws    = ">= 3.75"
+    aws    = ">= 3.75,<5.0"
     random = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
Resource `aws_kinesis_firehose_delivery_stream` has schema changes in version 5.0 of the AWS provider. This commit signals the incompatibility in the
  required_providers block.