### PR TITLE
fix(s3): set object ownership to ObjectWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ No modules.
 | [aws_kinesis_firehose_delivery_stream.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_ownership_controls.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [random_string.bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -23,11 +23,20 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket" {
+  count  = local.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.bucket[0].id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "bucket" {
   count = local.create_s3_bucket ? 1 : 0
 
-  bucket = aws_s3_bucket.bucket[0].id
-  acl    = "private"
+  bucket     = aws_s3_bucket.bucket[0].id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.bucket]
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "this" {


### PR DESCRIPTION
Due to an AWS API change to the default S3 settings, we have to set object ownership to be able to set the ACL and retain existing behavior.