### PR TITLE
chore(sensitive): mark the firehose delivery stream as a sensitive value

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,9 @@
 output "firehose_delivery_stream" {
   description = "Kinesis Firehose delivery stream towards Observe"
-  value       = aws_kinesis_firehose_delivery_stream.this
+  value = {
+    name = aws_kinesis_firehose_delivery_stream.this.name
+    arn  = aws_kinesis_firehose_delivery_stream.this.arn
+  }
 }
 
 output "firehose_iam_policy" {


### PR DESCRIPTION
## What does this PR do?

Trying to remove the warning / error related to the outputting of sensitive values
```
       │ Error: Output refers to sensitive values
       │ 
       │   on outputs.tf line 6:
       │    6: output "observe_kinesis_firehose" {
       │ 
       │ To reduce the risk of accidentally exporting sensitive data that was
       │ intended to be only internal, Terraform requires that any root module
       │ output containing sensitive data be explicitly marked as sensitive, to
       │ confirm your intent.
       │ 
       │ If you do intend to export this data, annotate the output value as
       │ sensitive by adding the following argument:
       │     sensitive = true
```
## Testing

made a terraform.tfvars file in `examples/eventbridge` and did an apply / output / destory loop
