### PR TITLE
feat: support OBSERVE_COLLECTION_ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ No modules.
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-kinesis-firehose-"` | no |
 | <a name="input_kinesis_stream"></a> [kinesis\_stream](#input\_kinesis\_stream) | Kinesis Data Stream ARN to configure as source | `object({ arn = string })` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of Kinesis Firehose resource | `string` | n/a | yes |
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `"observeinc.com"` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | `null` | no |
+| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID. Deprecated, please use observe\_collection\_endpoint instead | `string` | `null` | no |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain. Deprecated, please use observe\_collection\_endpoint instead | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe Token | `string` | n/a | yes |
 | <a name="input_observe_url"></a> [observe\_url](#input\_observe\_url) | Observe URL. Deprecated. | `string` | `""` | no |
 | <a name="input_s3_delivery_bucket"></a> [s3\_delivery\_bucket](#input\_s3\_delivery\_bucket) | S3 bucket to be used as backup for message delivery | <pre>object({<br>    arn = string<br>  })</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   access_key                   = var.observe_token
   create_s3_bucket             = var.s3_delivery_bucket == null
   s3_bucket_arn                = local.create_s3_bucket ? aws_s3_bucket.bucket[0].arn : var.s3_delivery_bucket.arn
-  observe_url                  = var.observe_url != "" ? var.observe_url : format("https://%s.collect.%s/v1/kinesis", var.observe_customer, var.observe_domain)
+  observe_url                  = coalesce(var.observe_url, try("${var.observe_collection_endpoint}/v1/kinesis", ""), try("https://${var.observe_customer}.collect.${var.observe_domain}/v1/kinesis", ""), "missing")
 }
 
 resource "random_string" "bucket_suffix" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,20 @@ variable "name" {
   type        = string
 }
 
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
+  default     = null
+  validation {
+    condition     = var.observe_collection_endpoint == null || can(regex("^https://.*$", var.observe_collection_endpoint))
+    error_message = "Endpoint must be a valid HTTPS URL."
+  }
+}
+
+variable "observe_customer" {
+  description = "Observe Customer ID. Deprecated, please use observe_collection_endpoint instead"
+  type        = string
+  default     = null
 }
 
 variable "observe_token" {
@@ -19,7 +30,7 @@ variable "observe_token" {
 }
 
 variable "observe_domain" {
-  description = "Observe domain"
+  description = "Observe domain. Deprecated, please use observe_collection_endpoint instead"
   type        = string
   nullable    = false
   default     = "observeinc.com"


### PR DESCRIPTION
This commit adds support for `collection_endpoint`, and deprecates both `customer` and `domain`.