### PR TITLE
fix: update docs to use collection endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Additionally, this repository provides submodules to interact with the Firehose 
 module "observe_kinesis_firehose" {
   source = "observeinc/kinesis-firehose/aws"
 
-  name                = "observe-kinesis-firehose"
-  observe_customer    = "<id>"
-  observe_token       = "<token>"
+  name                        = "observe-kinesis-firehose"
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = var.observe_token
 }
 ```
 
@@ -41,10 +41,10 @@ resource "aws_s3_bucket" "bucket" {
 module "observe_kinesis_firehose" {
   source = "observeinc/kinesis-firehose/aws"
 
-  name                = "observe-kinesis-firehose"
-  observe_customer    = "<id>"
-  observe_token       = "<token>"
-  s3_delivery_bucket  = aws_s3_bucket.bucket
+  name                        = "observe-kinesis-firehose"
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = var.observe_token
+  s3_delivery_bucket          = aws_s3_bucket.bucket
 }
 ```
 
@@ -62,10 +62,10 @@ resource "aws_kinesis_stream" "example" {
 module "observe_kinesis_firehose" {
   source = "observeinc/kinesis-firehose/aws"
 
-  name                = "observe-kinesis-firehose"
-  observe_customer    = "<id>"
-  observe_token       = "<token>"
-  kinesis_stream      = aws_kinesis_stream.example
+  name                        = "observe-kinesis-firehose"
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = "<token>"
+  kinesis_stream              = aws_kinesis_stream.example
 }
 ```
 
@@ -98,10 +98,10 @@ resource "aws_cloudwatch_log_group" "group" {
 module "observe_kinesis_firehose" {
   source = "observeinc/kinesis-firehose/aws"
 
-  name                 = "observe-kinesis-firehose"
-  observe_customer     = "<id>"
-  observe_token        = "<token>"
-  cloudwatch_log_group = aws_cloudwatch_log_group.group
+  name                        = "observe-kinesis-firehose"
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = "<token>"
+  cloudwatch_log_group        = aws_cloudwatch_log_group.group
 }
 ```
 

--- a/examples/cross-account/README.md
+++ b/examples/cross-account/README.md
@@ -90,8 +90,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 |------|-------------|------|---------|:--------:|
 | <a name="input_external_ids"></a> [external\_ids](#input\_external\_ids) | External ID array | `list(string)` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for firehose and matching IAM role | `string` | n/a | yes |
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 | <a name="input_user_arn"></a> [user\_arn](#input\_user\_arn) | ARN for external user granted access to assume role | `string` | n/a | yes |
 

--- a/examples/cross-account/main.tf
+++ b/examples/cross-account/main.tf
@@ -8,10 +8,10 @@ resource "aws_cloudwatch_log_group" "group" {
 }
 
 module "observe_kinesis_firehose" {
-  source           = "../.."
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
+  source = "../.."
+
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
 
   name                 = var.name
   cloudwatch_log_group = aws_cloudwatch_log_group.group

--- a/examples/cross-account/variables.tf
+++ b/examples/cross-account/variables.tf
@@ -1,17 +1,11 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe domain"
-  type        = string
-  default     = null
 }
 
 variable "name" {

--- a/examples/eks/README.md
+++ b/examples/eks/README.md
@@ -55,8 +55,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster Name | `string` | `"observe-eks-demo"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS Cluster Version | `string` | `"1.21"` | no |
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/eks/main.tf
+++ b/examples/eks/main.tf
@@ -15,9 +15,8 @@ provider "kubernetes" {
 module "observe_kinesis_firehose" {
   source = "../../modules/eks"
 
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
 
   eks_cluster_arn         = module.eks.cluster_arn
   pod_execution_role_arns = [for group in module.eks.fargate_profiles : group.fargate_profile_pod_execution_role_arn]

--- a/examples/eks/variables.tf
+++ b/examples/eks/variables.tf
@@ -12,19 +12,12 @@ variable "cluster_version" {
   default     = "1.21"
 }
 
-
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe Domain"
-  type        = string
-  default     = null
 }

--- a/examples/eventbridge/README.md
+++ b/examples/eventbridge/README.md
@@ -53,8 +53,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/eventbridge/main.tf
+++ b/examples/eventbridge/main.tf
@@ -10,10 +10,10 @@ resource "aws_cloudwatch_log_group" "group" {
 }
 
 module "observe_kinesis_firehose" {
-  source           = "../.."
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
+  source = "../.."
+
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
 
   name                 = random_pet.run.id
   cloudwatch_log_group = aws_cloudwatch_log_group.group

--- a/examples/eventbridge/variables.tf
+++ b/examples/eventbridge/variables.tf
@@ -1,15 +1,9 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe domain"
-  type        = string
-  default     = null
 }

--- a/examples/kinesis/README.md
+++ b/examples/kinesis/README.md
@@ -56,8 +56,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/kinesis/main.tf
+++ b/examples/kinesis/main.tf
@@ -5,10 +5,11 @@ provider "aws" {
 resource "random_pet" "run" {}
 
 module "observe_kinesis" {
-  source           = "../.."
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
+  source = "../.."
+
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+
 
   name           = random_pet.run.id
   kinesis_stream = aws_kinesis_stream.this

--- a/examples/kinesis/variables.tf
+++ b/examples/kinesis/variables.tf
@@ -1,15 +1,9 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe domain"
-  type        = string
-  default     = null
 }

--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -12,9 +12,10 @@ resource "aws_cloudwatch_log_group" "group" {
 
 module "observe_kinesis_firehose" {
   source           = "observeinc/kinesis-firehose/aws"
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  name             = random_pet.run.id
+
+  name                        = random_pet.run.id
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = "<token>"
 }
 
 module "observe_kinesis_firehose_cloudwatch_logs_subscription" {

--- a/modules/cloudwatch_metrics/README.md
+++ b/modules/cloudwatch_metrics/README.md
@@ -8,9 +8,10 @@ Kinesis Firehose stream.
 ```hcl
 module "kinesis_firehose" {
   source           = "observeinc/kinesis-firehose/aws"
-  name             = var.name
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
+
+  name                        = var.name
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = var.observe_token
 }
 
 module "cloudwatch_metrics" {

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -37,8 +37,8 @@ Terraform 0.13 and newer. Submit pull-requests to `main` branch.
 module "observe_kinesis_firehose" {
   source = "github.com/observeinc/terraform-aws-kinesis-firehose//eks?ref=main"
 
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = var.observe_token
 
   eks_cluster_arn = "arn:aws:eks:us-east-1:123456789012:cluster/cluster-name"
   pod_execution_role_arns = [
@@ -86,8 +86,9 @@ module "observe_kinesis_firehose" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_eks_cluster_arn"></a> [eks\_cluster\_arn](#input\_eks\_cluster\_arn) | EKS cluster ARN | `string` | n/a | yes |
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | `null` | no |
+| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID. Deprecated, please use observe\_collection\_endpoint instead | `string` | `null` | no |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain. Deprecated, please use observe\_collection\_endpoint instead | `string` | `null` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe Token | `string` | n/a | yes |
 | <a name="input_pod_execution_role_arns"></a> [pod\_execution\_role\_arns](#input\_pod\_execution\_role\_arns) | List of pod execution roles tied to Fargate profiles. | `list(string)` | n/a | yes |
 

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -30,10 +30,11 @@ resource "kubernetes_namespace_v1" "aws_observability" {
 module "observe_kinesis" {
   source = "../.."
 
-  name             = format("observe-eks-%s", local.eks_cluster_name)
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
+  name                        = format("observe-eks-%s", local.eks_cluster_name)
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_customer            = var.observe_customer
+  observe_token               = var.observe_token
+  observe_domain              = var.observe_domain
   common_attributes = {
     clusterUid = data.kubernetes_namespace_v1.default.metadata[0].uid
   }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -1,6 +1,13 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
+  default     = null
+}
+
+variable "observe_customer" {
+  description = "Observe Customer ID. Deprecated, please use observe_collection_endpoint instead"
+  type        = string
+  default     = null
 }
 
 variable "observe_token" {
@@ -9,7 +16,7 @@ variable "observe_token" {
 }
 
 variable "observe_domain" {
-  description = "Observe Domain"
+  description = "Observe domain. Deprecated, please use observe_collection_endpoint instead"
   type        = string
   default     = null
 }

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -18,9 +18,9 @@ resource "aws_cloudwatch_event_rule" "wildcard" {
 module "observe_kinesis_firehose" {
   source = "observeinc/kinesis-firehose/aws"
 
-  name             = "observe-kinesis-firehose"
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
+  name                        = "observe-kinesis-firehose"
+  observe_collection_endpoint = "https://<id>.collect.observeinc.com"
+  observe_token               = var.observe_token
 }
 
 module "observe_firehose_eventbridge" {


### PR DESCRIPTION
This commit updates all docs and examples to use `observe_collection_endpoint` rather than `observe_customer` and `observe_domain`.