### PR TITLE
feat: bump AWS provider to 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,15 @@ This repository contains examples of how to solve for concrete usecases:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75, <5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75, <5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
@@ -178,8 +178,6 @@ No modules.
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe Token | `string` | n/a | yes |
 | <a name="input_observe_url"></a> [observe\_url](#input\_observe\_url) | Observe URL. Deprecated. | `string` | `""` | no |
 | <a name="input_s3_delivery_bucket"></a> [s3\_delivery\_bucket](#input\_s3\_delivery\_bucket) | S3 bucket to be used as backup for message delivery | <pre>object({<br>    arn = string<br>  })</pre> | `null` | no |
-| <a name="input_s3_delivery_buffer_interval"></a> [s3\_delivery\_buffer\_interval](#input\_s3\_delivery\_buffer\_interval) | Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. | `number` | `300` | no |
-| <a name="input_s3_delivery_buffer_size"></a> [s3\_delivery\_buffer\_size](#input\_s3\_delivery\_buffer\_size) | Buffer incoming data to the specified size, in MiBs, before delivering it to the destination. | `number` | `5` | no |
 | <a name="input_s3_delivery_cloudwatch_log_stream_name"></a> [s3\_delivery\_cloudwatch\_log\_stream\_name](#input\_s3\_delivery\_cloudwatch\_log\_stream\_name) | Log stream name for S3 delivery logs. If empty, log stream will be disabled | `string` | `"S3Delivery"` | no |
 | <a name="input_s3_delivery_compression_format"></a> [s3\_delivery\_compression\_format](#input\_s3\_delivery\_compression\_format) | The compression format. If no value is specified, the default is UNCOMPRESSED. | `string` | `"UNCOMPRESSED"` | no |
 | <a name="input_s3_delivery_prefix"></a> [s3\_delivery\_prefix](#input\_s3\_delivery\_prefix) | The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered Amazon S3 files | `string` | `null` | no |

--- a/examples/cross-account/README.md
+++ b/examples/cross-account/README.md
@@ -58,15 +58,15 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/examples/cross-account/versions.tf
+++ b/examples/cross-account/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/eks/README.md
+++ b/examples/eks/README.md
@@ -21,8 +21,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.20.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
@@ -30,21 +30,23 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.20.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 18.3.1 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 18.31.2 |
 | <a name="module_observe_kinesis_firehose"></a> [observe\_kinesis\_firehose](#module\_observe\_kinesis\_firehose) | ../../modules/eks | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.2.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_subnet.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [random_pet.run](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/pet) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
@@ -53,8 +55,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster Name | `string` | `"observe-eks-demo"` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS Cluster Version | `string` | `"1.21"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster Name | `string` | `null` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS Cluster Version | `string` | `"1.27"` | no |
 | <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 

--- a/examples/eks/eks.tf
+++ b/examples/eks/eks.tf
@@ -1,7 +1,7 @@
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
-  version         = "18.3.1"
-  cluster_name    = var.cluster_name
+  version         = "18.31.2"
+  cluster_name    = local.cluster_name
   cluster_version = var.cluster_version
   subnet_ids      = module.vpc.private_subnets
 

--- a/examples/eks/main.tf
+++ b/examples/eks/main.tf
@@ -1,3 +1,7 @@
+locals {
+  cluster_name = var.cluster_name != null ? var.cluster_name : random_pet.run.id
+}
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }
@@ -5,6 +9,8 @@ data "aws_eks_cluster" "cluster" {
 data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.cluster_id
 }
+
+resource "random_pet" "run" {}
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint

--- a/examples/eks/variables.tf
+++ b/examples/eks/variables.tf
@@ -1,15 +1,14 @@
 variable "cluster_name" {
   description = "EKS Cluster Name"
   type        = string
-  nullable    = false
-  default     = "observe-eks-demo"
+  default     = null
 }
 
 variable "cluster_version" {
   description = "EKS Cluster Version"
   type        = string
   nullable    = false
-  default     = "1.21"
+  default     = "1.27"
 }
 
 variable "observe_collection_endpoint" {

--- a/examples/eks/versions.tf
+++ b/examples/eks/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = ">= 5.0"
     }
 
     random = {

--- a/examples/eks/vpc.tf
+++ b/examples/eks/vpc.tf
@@ -2,9 +2,9 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.2.0"
+  version = "~> 5.0"
 
-  name                 = var.cluster_name
+  name                 = local.cluster_name
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
   private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
@@ -14,17 +14,17 @@ module "vpc" {
   enable_dns_hostnames = true
 
   tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
   }
 
   public_subnet_tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
-    "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
   }
 
   private_subnet_tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
-    "kubernetes.io/role/internal-elb"           = "1"
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
   }
 }
 

--- a/examples/eventbridge/README.md
+++ b/examples/eventbridge/README.md
@@ -23,15 +23,15 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/examples/eventbridge/versions.tf
+++ b/examples/eventbridge/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/kinesis/README.md
+++ b/examples/kinesis/README.md
@@ -23,15 +23,15 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/examples/kinesis/versions.tf
+++ b/examples/kinesis/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -43,23 +43,6 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
   name        = var.name
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = local.s3_bucket_arn
-
-    buffer_size        = var.s3_delivery_buffer_size
-    buffer_interval    = var.s3_delivery_buffer_interval
-    compression_format = var.s3_delivery_compression_format
-    prefix             = var.s3_delivery_prefix
-    # kms_key_arn
-
-    cloudwatch_logging_options {
-      enabled         = local.enable_s3_logging
-      log_group_name  = local.enable_s3_logging ? var.cloudwatch_log_group.name : ""
-      log_stream_name = local.enable_s3_logging ? var.s3_delivery_cloudwatch_log_stream_name : ""
-    }
-  }
-
   dynamic "kinesis_source_configuration" {
     for_each = local.enable_kinesis_source ? [1] : []
     content {
@@ -87,6 +70,20 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
           name  = common_attributes.key
           value = common_attributes.value
         }
+      }
+    }
+
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = local.s3_bucket_arn
+
+      compression_format = var.s3_delivery_compression_format
+      prefix             = var.s3_delivery_prefix
+
+      cloudwatch_logging_options {
+        enabled         = local.enable_s3_logging
+        log_group_name  = local.enable_s3_logging ? var.cloudwatch_log_group.name : ""
+        log_stream_name = local.enable_s3_logging ? var.s3_delivery_cloudwatch_log_stream_name : ""
       }
     }
 

--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -32,14 +32,14 @@ module "observe_kinesis_firehose_cloudwatch_logs_subscription" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/cloudwatch_logs_subscription/versions.tf
+++ b/modules/cloudwatch_logs_subscription/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/cloudwatch_metrics/README.md
+++ b/modules/cloudwatch_metrics/README.md
@@ -35,14 +35,14 @@ module "cloudwatch_metrics" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/cloudwatch_metrics/versions.tf
+++ b/modules/cloudwatch_metrics/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.42.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -53,8 +53,8 @@ module "observe_kinesis_firehose" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15, < 4.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -62,7 +62,7 @@ module "observe_kinesis_firehose" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0 |
 
 ## Modules

--- a/modules/eks/versions.tf
+++ b/modules/eks/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15, < 4.0"
+      version = ">= 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -38,15 +38,15 @@ module "observe_firehose_eventbridge" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/eventbridge/versions.tf
+++ b/modules/eventbridge/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/variables.tf
+++ b/variables.tf
@@ -94,20 +94,6 @@ variable "http_endpoint_content_encoding" {
   default     = "GZIP"
 }
 
-variable "s3_delivery_buffer_interval" {
-  description = "Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination."
-  type        = number
-  nullable    = false
-  default     = 300
-}
-
-variable "s3_delivery_buffer_size" {
-  description = "Buffer incoming data to the specified size, in MiBs, before delivering it to the destination."
-  type        = number
-  nullable    = false
-  default     = 5
-}
-
 variable "s3_delivery_compression_format" {
   description = "The compression format. If no value is specified, the default is UNCOMPRESSED."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.75, <5.0"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Terraform AWS provider 5.0 introduces some schema incompatabilities for the aws_kinesis_firehose resource. We address them in this comit and bump the minimum required version accordingly.

For users upgrading from older providers, this change should be a no-op.

Introduce tests for the EKS example module, since that is the most susceptible of breakage.
