### PR TITLE
Support sending additional CloudWatch metrics statistics

### DIFF
--- a/modules/cloudwatch_metrics/main.tf
+++ b/modules/cloudwatch_metrics/main.tf
@@ -49,4 +49,19 @@ resource "aws_cloudwatch_metric_stream" "main" {
       namespace = exclude_filter.value
     }
   }
+
+  dynamic "statistics_configuration" {
+    for_each = var.statistics_configurations
+    content {
+      additional_statistics = statistics_configuration.value.additional_statistics
+
+      dynamic "include_metric" {
+        for_each = statistics_configuration.value.include_metrics
+        content {
+          namespace   = include_metric.value.namespace
+          metric_name = include_metric.value.metric_name
+        }
+      }
+    }
+  }
 }

--- a/modules/cloudwatch_metrics/variables.tf
+++ b/modules/cloudwatch_metrics/variables.tf
@@ -41,6 +41,18 @@ variable "exclude_filters" {
   default     = []
 }
 
+variable "statistics_configurations" {
+  description = "A list of additional statistics configurations to include."
+  type = list(object({
+    additional_statistics = list(string)
+    include_metrics = list(object({
+      namespace   = string
+      metric_name = string
+    }))
+  }))
+  default = null
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)


### PR DESCRIPTION
## What does this PR do?

This PR adds support for specifying additional statistics configurations on the CloudWatch metrics stream which is supported by the [underlying Terraform resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_stream#statistics_configuration). The, [terraform-aws-collection](https://github.com/observeinc/terraform-aws-collection) module makes use of this module to configure a CloudWatch metric stream. The hope is that, eventually, the [terraform-aws-collection](https://github.com/observeinc/terraform-aws-collection) module would expose the new statistics configuration capability of this module via an appropriate variable.

## Motivation

By default, CloudWatch [only sends certain statistics (Minimum, Maximum, SampleCount, and Sum) for metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-statistics.html). Sometimes it's desirable to have additional statistics for given metrics in Observe. This PR gets us closer to having the configuration for including these additional statistics in Terraform code.

For example, in my case, I want to send the p90, p95, and p99 statistics for the `TargetResponseTime` of `AWS/ApplicationELB` resources to Observe. To do that, I would pass something like the following as `var.statistics_configurations`:

``` terraform
[
  {
    additional_statistics = ["p90", "p95", "p99"]
    include_metrics = [
      {
        metric_name = "TargetResponseTime"
        namespace   = "AWS/ApplicationELB"
      }
    ]
  }
]
``` 

## Testing

I have tested using a forked version of the [terraform-aws-collection](https://github.com/observeinc/terraform-aws-collection) module that passes through values for `var.statistics_configurations` (see: https://github.com/kuleszaj/terraform-aws-collection/pull/1/files). I have specifically tested the defaults (`null`, and `[]`), and also specifying multiple different statistics configurations (such as the one provided above). It has behaved as I expected: no affect with defaults, and appropriately adds `statistics_configuration` blocks when provided via `var.statistics_configurations`.

