### PR TITLE
feat: add  http_endpoint_s3_backup_mode var to cross-account

### DIFF
--- a/examples/cross-account/README.md
+++ b/examples/cross-account/README.md
@@ -89,6 +89,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_external_ids"></a> [external\_ids](#input\_external\_ids) | External ID array | `list(string)` | `null` | no |
+| <a name="input_http_endpoint_s3_backup_mode"></a> [http\_endpoint\_s3\_backup\_mode](#input\_http\_endpoint\_s3\_backup\_mode) | S3 backup mode for Kinesis Firehose HTTP endpoint. By default, only data that cannot be delivered to Observe via HTTP is written to S3. To backup all data to S3, set this to `AllData`. | `string` | `"FailedDataOnly"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for firehose and matching IAM role | `string` | n/a | yes |
 | <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |

--- a/examples/cross-account/main.tf
+++ b/examples/cross-account/main.tf
@@ -15,6 +15,8 @@ module "observe_kinesis_firehose" {
 
   name                 = var.name
   cloudwatch_log_group = aws_cloudwatch_log_group.group
+
+  http_endpoint_s3_backup_mode = var.http_endpoint_s3_backup_mode
 }
 
 resource "aws_iam_role" "this" {

--- a/examples/cross-account/variables.tf
+++ b/examples/cross-account/variables.tf
@@ -13,6 +13,13 @@ variable "name" {
   description = "Name for firehose and matching IAM role"
 }
 
+variable "http_endpoint_s3_backup_mode" {
+  type        = string
+  description = "S3 backup mode for Kinesis Firehose HTTP endpoint. By default, only data that cannot be delivered to Observe via HTTP is written to S3. To backup all data to S3, set this to `AllData`."
+  nullable    = false
+  default     = "FailedDataOnly"
+}
+
 variable "user_arn" {
   type        = string
   description = "ARN for external user granted access to assume role"


### PR DESCRIPTION
## What does this PR do?

Adds http_endpoint_s3_backup_mode to the cross-account example to enable users to turn
on backup to S3 for all data

## Testing

Tested locally using new and existing streams, tested value set and also omitted
