### PR TITLE
fix: add compression var for cross account firehose

### DIFF
--- a/examples/cross-account/README.md
+++ b/examples/cross-account/README.md
@@ -93,6 +93,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | <a name="input_name"></a> [name](#input\_name) | Name for firehose and matching IAM role | `string` | n/a | yes |
 | <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
+| <a name="input_s3_delivery_compression_format"></a> [s3\_delivery\_compression\_format](#input\_s3\_delivery\_compression\_format) | The compression format. If no value is specified, the default is UNCOMPRESSED. | `string` | `"UNCOMPRESSED"` | no |
 | <a name="input_user_arn"></a> [user\_arn](#input\_user\_arn) | ARN for external user granted access to assume role | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/cross-account/main.tf
+++ b/examples/cross-account/main.tf
@@ -16,7 +16,8 @@ module "observe_kinesis_firehose" {
   name                 = var.name
   cloudwatch_log_group = aws_cloudwatch_log_group.group
 
-  http_endpoint_s3_backup_mode = var.http_endpoint_s3_backup_mode
+  http_endpoint_s3_backup_mode   = var.http_endpoint_s3_backup_mode
+  s3_delivery_compression_format = var.s3_delivery_compression_format
 }
 
 resource "aws_iam_role" "this" {

--- a/examples/cross-account/variables.tf
+++ b/examples/cross-account/variables.tf
@@ -20,6 +20,13 @@ variable "http_endpoint_s3_backup_mode" {
   default     = "FailedDataOnly"
 }
 
+variable "s3_delivery_compression_format" {
+  description = "The compression format. If no value is specified, the default is UNCOMPRESSED."
+  type        = string
+  nullable    = false
+  default     = "UNCOMPRESSED"
+}
+
 variable "user_arn" {
   type        = string
   description = "ARN for external user granted access to assume role"


### PR DESCRIPTION
## What does this PR do?

When setting up a cross-accunt firehose and backup to S3, it's not possible to set this to be compressed, this resolves that issue

## Testing

None
