### PR TITLE
feat: Add Lifecycle rule for retention to S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ No modules.
 | [aws_kinesis_firehose_delivery_stream.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_lifecycle_configuration.retention](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [random_string.bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
@@ -180,6 +181,7 @@ No modules.
 | <a name="input_s3_delivery_bucket"></a> [s3\_delivery\_bucket](#input\_s3\_delivery\_bucket) | S3 bucket to be used as backup for message delivery | <pre>object({<br>    arn = string<br>  })</pre> | `null` | no |
 | <a name="input_s3_delivery_cloudwatch_log_stream_name"></a> [s3\_delivery\_cloudwatch\_log\_stream\_name](#input\_s3\_delivery\_cloudwatch\_log\_stream\_name) | Log stream name for S3 delivery logs. If empty, log stream will be disabled | `string` | `"S3Delivery"` | no |
 | <a name="input_s3_delivery_compression_format"></a> [s3\_delivery\_compression\_format](#input\_s3\_delivery\_compression\_format) | The compression format. If no value is specified, the default is UNCOMPRESSED. | `string` | `"UNCOMPRESSED"` | no |
+| <a name="input_s3_delivery_data_retention"></a> [s3\_delivery\_data\_retention](#input\_s3\_delivery\_data\_retention) | Days to retain files in S3 | `number` | `30` | no |
 | <a name="input_s3_delivery_prefix"></a> [s3\_delivery\_prefix](#input\_s3\_delivery\_prefix) | The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered Amazon S3 files | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 

--- a/examples/cross-account/README.md
+++ b/examples/cross-account/README.md
@@ -94,6 +94,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 | <a name="input_s3_delivery_compression_format"></a> [s3\_delivery\_compression\_format](#input\_s3\_delivery\_compression\_format) | The compression format. If no value is specified, the default is UNCOMPRESSED. | `string` | `"UNCOMPRESSED"` | no |
+| <a name="input_s3_delivery_data_retention"></a> [s3\_delivery\_data\_retention](#input\_s3\_delivery\_data\_retention) | Days to retain files in S3. | `number` | `30` | no |
 | <a name="input_user_arn"></a> [user\_arn](#input\_user\_arn) | ARN for external user granted access to assume role | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/cross-account/main.tf
+++ b/examples/cross-account/main.tf
@@ -18,6 +18,7 @@ module "observe_kinesis_firehose" {
 
   http_endpoint_s3_backup_mode   = var.http_endpoint_s3_backup_mode
   s3_delivery_compression_format = var.s3_delivery_compression_format
+  s3_delivery_data_retention     = var.s3_delivery_data_retention
 }
 
 resource "aws_iam_role" "this" {

--- a/examples/cross-account/variables.tf
+++ b/examples/cross-account/variables.tf
@@ -27,6 +27,13 @@ variable "s3_delivery_compression_format" {
   default     = "UNCOMPRESSED"
 }
 
+variable "s3_delivery_data_retention" {
+  description = "Days to retain files in S3."
+  type        = number
+  nullable    = false
+  default     = 30
+}
+
 variable "user_arn" {
   type        = string
   description = "ARN for external user granted access to assume role"

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,13 @@ variable "s3_delivery_compression_format" {
   default     = "UNCOMPRESSED"
 }
 
+variable "s3_delivery_data_retention" {
+  description = "Days to retain files in S3"
+  type        = number
+  nullable    = false
+  default     = 30
+}
+
 variable "s3_delivery_prefix" {
   description = "The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3 files"
   type        = string


### PR DESCRIPTION
## What does this PR do?

Adds the ability to set data retention when an S3 bucket is used for failed messages or backup

## Motivation

In some case the bucket was growing retaining data that was not needed

## Testing

Basic testing
