### PR TITLE
fix: Fix missing S3 Bucket retention filter

### DIFF
--- a/examples/eks/README.md
+++ b/examples/eks/README.md
@@ -22,7 +22,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
@@ -30,7 +30,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules

--- a/examples/eks/versions.tf
+++ b/examples/eks/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
 
     random = {

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "retention" {
   rule {
     id     = "retention"
     status = "Enabled"
+    filter {}
     expiration {
       days = local.s3_bucked_data_retention
     }


### PR DESCRIPTION
## What does this PR do?

Previously the retention configuration did not include a `filter` block, and this will be
required in the future, so this resolves that

## Testing

Not tested
